### PR TITLE
add dot to the option of text extension

### DIFF
--- a/src/inline-scripts/fs-helpers.js
+++ b/src/inline-scripts/fs-helpers.js
@@ -44,7 +44,7 @@ function getNewFileHandle() {
     const opts = {
       types: [{
         description: 'Text file',
-        accept: {'text/plain': ['txt']},
+        accept: {'text/plain': ['.txt']},
       }],
     };
     return window.showSaveFilePicker(opts);


### PR DESCRIPTION
For Chrome 86 and later, without a dot, window.showSaveFilePicker cause an exception with error `"Failed to execute 'showSaveFilePicker' on 'Window': Extension 'txt' must start with '.'."`

I tested locally it has no problem.